### PR TITLE
fix(zeromq): ```Socket``` class ```constructor``` definition missing

### DIFF
--- a/types/zeromq/index.d.ts
+++ b/types/zeromq/index.d.ts
@@ -133,6 +133,11 @@ export class Context {
 
 export class Socket extends EventEmitter {
     /**
+     * @param type keyof SocketTypes | SocketTypes[keyof SocketTypes]
+     */
+    constructor(type: keyof SocketTypes | SocketTypes[keyof SocketTypes]);
+    
+    /**
      * Set `opt` to `val`.
      *
      * @param opt Option


### PR DESCRIPTION
The declaration of the ```Socket``` class constructor does not match the class implementation in the [```zeromq```](https://github.com/zeromq/zeromq.js) package

More specifically:
On this line [here](https://github.com/zeromq/zeromq.js/blob/64a92ab68c3918490ff45626365bf7b47c580e90/lib/index.js#L294), the constructor requires a ```type``` argument, which is not present in the ```Socket``` constructor type declaration.

Adding the constructor declaration allows us to extend the ```Socket``` class without getting an undefined ```type``` error in typescript.

* [x]  Use a meaningful title for the pull request. Include the name of the package modified.
* [x]  Test the change in your own code. (Compile and run.)
* [x]  [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
* [x]  Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
* [x]  Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
* [x]  [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

 * [x]  Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zeromq/zeromq.js/blob/64a92ab68c3918490ff45626365bf7b47c580e90/lib/index.js#L294
* [x]  If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.